### PR TITLE
Fix: show error if there are no results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "ansi_term",
  "argh",
  "eyre",
+ "openssl",
  "reqwest",
  "serde",
  "serde_json",
@@ -516,6 +517,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.24.0+1.1.1s"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +534,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ reqwest = "0.11.2"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 tokio = { version = "1.3.0", features = ["full"] }
+openssl = { version = "0.10", features = ["vendored"] }
 
 [profile.release]
 opt-level = 'z' 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,10 @@ async fn main() -> Result<()> {
         .iter()
         .filter(|e| e.meta.id == args.word || e.meta.id.contains(":"))
         .collect::<Vec<&WelcomeElement>>();
+    if json.len() == 0 {
+        eprintln!("No results found");
+        exit(1);
+    }
     for def in json {
         println!("");
         println!(


### PR DESCRIPTION
Dictionaryapi suggests most possible words even if there's a mistake, however, it doesn't return any relevant info if a "word" doesn't match at all and the JSON string stays empty. So we can use it to print that there's nothing found,

Edit: There's also an issue I encountered when the Rust compiler tries to use OpenSSL header files, but can't find them at all. Maybe I'm doing something wrong(?) Adding `openssl` crate with `vendored` feature enabled (which will pull the OpenSSL master branch, fixing the issue)
### Image
![2022-12-19_21-40](https://user-images.githubusercontent.com/71683721/208472500-b7ca9094-6554-41c7-b694-a44d2966f77c.png)

